### PR TITLE
Route fire method through TransactionalDispatcher

### DIFF
--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -254,6 +254,19 @@ class TransactionalDispatcher implements DispatcherContract
     }
 
     /**
+     * Fire an event and call the listeners.
+     *
+     * @param  string|object  $event
+     * @param  mixed  $payload
+     * @param  bool  $halt
+     * @return array|null
+     */
+    public function fire($event, $payload = [], $halt = false)
+    {
+        return $this->dispatch($event, $payload, $halt);
+    }
+
+    /**
      * Register an event and payload to be fired later.
      *
      * @param  string $event


### PR DESCRIPTION
The `fire` method is an alias to the `dispatch` method in `Illuminate\Event\Dispatcher` and should be routed through the TransactionalDispatcher too to. Events created through models are now too transaction-aware.