### PR TITLE
Keep the payload context in dispatched events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
     "prefer-stable": true,
     "config": {
         "sort-packages": true
+    },
+    "require-dev": {
+        "orchestra/testbench": "3.5.* || 3.6.*"
     }
 }

--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -146,7 +146,10 @@ class TransactionalDispatcher implements DispatcherContract
         $connectionId = $connection->getName();
         $transactionLevel = $this->transactionLevel;
 
-        $eventData = compact('event', 'payload');
+		$eventData = [
+			'event' => $event,
+			'payload' => clone $payload,
+		];
         $transactionLevelEvents = &$this->pendingEvents[$connectionId][$transactionLevel];
         $transactionLevelEvents[count($transactionLevelEvents) - 1][] = $eventData;
     }

--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -148,7 +148,7 @@ class TransactionalDispatcher implements DispatcherContract
 
         $eventData = [
             'event' => $event,
-            'payload' => clone $payload,
+            'payload' => is_object($payload) ? clone $payload : $payload,
         ];
         $transactionLevelEvents = &$this->pendingEvents[$connectionId][$transactionLevel];
         $transactionLevelEvents[count($transactionLevelEvents) - 1][] = $eventData;

--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -146,10 +146,10 @@ class TransactionalDispatcher implements DispatcherContract
         $connectionId = $connection->getName();
         $transactionLevel = $this->transactionLevel;
 
-		$eventData = [
-			'event' => $event,
-			'payload' => clone $payload,
-		];
+        $eventData = [
+            'event' => $event,
+            'payload' => clone $payload,
+        ];
         $transactionLevelEvents = &$this->pendingEvents[$connectionId][$transactionLevel];
         $transactionLevelEvents[count($transactionLevelEvents) - 1][] = $eventData;
     }

--- a/src/config/transactional-events.php
+++ b/src/config/transactional-events.php
@@ -24,7 +24,6 @@ return [
         // 'eloquent.*',
         'eloquent.booted',
         'eloquent.retrieved',
-        'eloquent.created',
         'eloquent.saved',
         'eloquent.updated',
         'eloquent.created',

--- a/tests/TransactionalDispatcherTest.php
+++ b/tests/TransactionalDispatcherTest.php
@@ -192,12 +192,12 @@ class TransactionalDispatcherTest extends TestCase
             $_SERVER['__events'] = 'bar';
         });
 
+        DB::transaction(function () {
             DB::transaction(function () {
-                DB::transaction(function () {
-                    $this->dispatcher->dispatch('foo');
-                    DB::rollBack();
-                });
+                $this->dispatcher->dispatch('foo');
+                DB::rollBack();
             });
+        });
 
         $this->assertArrayNotHasKey('__events', $_SERVER);
     }


### PR DESCRIPTION
If it isn't, then an audit monitor listening on the updated event won't see any differences, since the model attributes will already have been merged back in original.