### PR TITLE
Fix infinite loop caused by TransactionCommitted

### DIFF
--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -163,15 +163,17 @@ class TransactionalDispatcher implements DispatcherContract
     protected function dispatchPendingEvents(ConnectionInterface $connection)
     {
         $connectionId = $connection->getName();
-        foreach ($this->pendingEvents[$connectionId] as $transactionsEvents) {
+        $consumingEvents = $this->pendingEvents[$connectionId];
+
+        unset($this->pendingEvents[$connectionId]);
+
+        foreach ($consumingEvents as $transactionsEvents) {
             foreach ($transactionsEvents as $transactionEvents) {
                 foreach ($transactionEvents as $event) {
                     $this->dispatcher->dispatch($event['event'], $event['payload']);
                 }
             }
         }
-
-        unset($this->pendingEvents[$connectionId]);
     }
 
     /**


### PR DESCRIPTION
bugfix: Infinity loop bug cause by `TransactionCommitted` event

```php
Route::get('test/bug', function () {
    app('db')->beginTransaction();

    event(new \App\Events\FooEvent());
    event(new \App\Events\BarEvent());

    app('db')->commit();

    return 'success';
});

class FooEvent
{
    use Dispatchable;
}

class BarEvent
{
    use Dispatchable;
}

// It does not matter to use queue or not
class FooListener implements ShouldQueue 
{
    use InteractsWithQueue;

    public function handle(FooEvent $event)
    {
        // You can keep it empty
    }
}

class BarListener
{
    public function handle(BarEvent $event)
    {
        app('db')->beginTransaction();

        // business code or keep empty

        app('db')->commit(); // The commit will emit TransactionCommitted
    }
}


```

```php
foreach ($consumingEvents as $transactionsEvents) {
    foreach ($transactionsEvents as $transactionEvents) {
        foreach ($transactionEvents as $event) {
            $this->dispatcher->dispatch($event['event'], $event['payload']);  
            // Infinity Loop (emit TransactionCommitted will run into this function again which cause infinify loop)
        }
    }
}

unset($this->pendingEvents[$connectionId]);  // Never reach here
```