### PR TITLE
Added check for non-existing pendingEvent connection-keys

### DIFF
--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -143,7 +143,7 @@ class TransactionalDispatcher implements DispatcherContract
      */
     protected function addPendingEvent($connection, $event, $payload)
     {
-        if (!$this->isPrepared($connection)) {
+        if (! $this->isPrepared($connection)) {
             return;
         }
 

--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -145,10 +145,10 @@ class TransactionalDispatcher implements DispatcherContract
     {
         $connectionId = $connection->getName();
         $transactionLevel = $this->transactionLevel;
-        
+
         // When working with multiple connections, we might come across
         // one that isn't prepared yet, nor will it have any events
-        if (!array_key_exists($connectionId, $this->pendingEvents)) {
+        if (! array_key_exists($connectionId, $this->pendingEvents)) {
             return;
         }
 

--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -143,14 +143,12 @@ class TransactionalDispatcher implements DispatcherContract
      */
     protected function addPendingEvent($connection, $event, $payload)
     {
-        $connectionId = $connection->getName();
-        $transactionLevel = $this->transactionLevel;
-
-        // When working with multiple connections, we might come across
-        // one that isn't prepared yet, nor will it have any events
-        if (! array_key_exists($connectionId, $this->pendingEvents)) {
+        if ($this->isPrepared($connection)) {
             return;
         }
+
+        $connectionId = $connection->getName();
+        $transactionLevel = $this->transactionLevel;
 
         $eventData = [
             'event' => $event,
@@ -266,6 +264,17 @@ class TransactionalDispatcher implements DispatcherContract
         }
 
         return false;
+    }
+
+    /**
+     * Check if a connection has been prepared for transactional events.
+     *
+     * @param   \Illuminate\Database\ConnectionInterface    $connection
+     * @return  bool
+     */
+    private function isPrepared($connection)
+    {
+        return isset($this->pendingEvents[$connection->getName()]);
     }
 
     /**

--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -143,7 +143,7 @@ class TransactionalDispatcher implements DispatcherContract
      */
     protected function addPendingEvent($connection, $event, $payload)
     {
-        if ($this->isPrepared($connection)) {
+        if (!$this->isPrepared($connection)) {
             return;
         }
 

--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -145,6 +145,12 @@ class TransactionalDispatcher implements DispatcherContract
     {
         $connectionId = $connection->getName();
         $transactionLevel = $this->transactionLevel;
+        
+        // When working with multiple connections, we don't might come across
+        // one that isn't prepared yet, nor will it have any events
+        if (!array_key_exists($connectionId, $this->pendingEvents)) {
+            return;
+        }
 
         $eventData = [
             'event' => $event,

--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -146,7 +146,7 @@ class TransactionalDispatcher implements DispatcherContract
         $connectionId = $connection->getName();
         $transactionLevel = $this->transactionLevel;
         
-        // When working with multiple connections, we don't might come across
+        // When working with multiple connections, we might come across
         // one that isn't prepared yet, nor will it have any events
         if (!array_key_exists($connectionId, $this->pendingEvents)) {
             return;


### PR DESCRIPTION
I work with a multi-tenant application which uses two connections. If I queue an event while transactioning on my tenant connection, it will try to do something with my main connection, which obviously hasn't been prepared (has no array), thus it throws an error because $transactionLevelEvents ends up being NULL. This prevents non-prepared connections in pendingEvents from causing problems.