### PR TITLE
Make TransactionalDispatcher extend EventDispatcher

### DIFF
--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -12,7 +12,7 @@ use Illuminate\Events\Dispatcher as EventDispatcher;
 use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
-class TransactionalDispatcher implements extends EventDispatcher DispatcherContract
+class TransactionalDispatcher extends EventDispatcher implements DispatcherContract
 {
     /**
      * The connection resolver.

--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -12,7 +12,7 @@ use Illuminate\Events\Dispatcher as EventDispatcher;
 use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
-class TransactionalDispatcher implements DispatcherContract
+class TransactionalDispatcher implements extends EventDispatcher DispatcherContract
 {
     /**
      * The connection resolver.


### PR DESCRIPTION
That's some problem when I use TransactionalDispatcher And Sentry both.

https://github.com/getsentry/sentry-laravel/blob/master/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php#L72

`SentryLaravelEventHandler::handle(Dispatcher $dipatch)` require a `Dispatcher` but got a `TransactionalDispatcher`, to work perferlly `TransactionalDispatcher` can extends `Dispatch`