### PR TITLE
Fix dispatcher not registering when db is already resolved

### DIFF
--- a/src/Neves/Events/EventServiceProvider.php
+++ b/src/Neves/Events/EventServiceProvider.php
@@ -23,7 +23,7 @@ class EventServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->app->afterResolving('db', function ($connectionResolver) {
+        $resolver = function () {
             $eventDispatcher = $this->app->make(EventDispatcher::class);
             $this->app->extend('events', function () use ($eventDispatcher) {
                 $dispatcher = new TransactionalDispatcher($eventDispatcher);
@@ -32,7 +32,13 @@ class EventServiceProvider extends ServiceProvider
 
                 return $dispatcher;
             });
-        });
+        };
+
+        if ($this->app->resolved('db')) {
+            $resolver();
+        } else {
+            $this->app->afterResolving('db', $resolver);
+        }
     }
 
     /**


### PR DESCRIPTION
This may be a Lumen-specific situation. I found that the EventDispatcher was never being extended due to the db dependency having already been resolved at the point where EventServiceProvider::register was fired.