### PR TITLE
Add DatabaseTransactions trait for transactional events

### DIFF
--- a/src/Neves/Testing/DatabaseTransactions.php
+++ b/src/Neves/Testing/DatabaseTransactions.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Neves\Testing;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions as BaseDatabaseTransactions;
+
+trait DatabaseTransactions
+{
+    use BaseDatabaseTransactions;
+
+    public function beginDatabaseTransaction()
+    {
+        $emptyDispatcher = new \Illuminate\Events\Dispatcher;
+        $database = $this->app->make('db');
+
+        foreach ($this->connectionsToTransact() as $name) {
+            $connection = $database->connection($name);
+
+            $currentDispatcher = $connection->getEventDispatcher();
+            $connection->setEventDispatcher($emptyDispatcher);
+            $connection->beginTransaction();
+            $connection->setEventDispatcher($currentDispatcher);
+        }
+
+        $this->beforeApplicationDestroyed(function () use ($database, $emptyDispatcher) {
+            foreach ($this->connectionsToTransact() as $name) {
+                $connection = $database->connection($name);
+
+                $currentDispatcher = $connection->getEventDispatcher();
+                $connection->setEventDispatcher($emptyDispatcher);
+                $connection->rollBack();
+                $connection->setEventDispatcher($currentDispatcher);
+
+                $connection->disconnect();
+            }
+        });
+    }
+}


### PR DESCRIPTION
In my test suite I'm not using `RefreshDatabase` but `DatabaseTransactions`.

The reason is that I've a custom system in place which primes the database _once_ before all tests are run and not for every tests. Because I can't use sqlite but the actual DB driver, this is much more faster.

With this trait I can replace the vanilla one and transactional events and their effect can be tested like anything else.

### Mildly related question

I've a question regarding https://github.com/fntneves/laravel-transactional-events#known-issues though: I re-read the paragraph multiple times but TBH, it's not clear whether this packages `RefreshDatabase` is basically required to be used or not.

I saw that you landed https://github.com/laravel/framework/pull/23832 some time ago but this package actually does not use any of this:
- the trait has a slightly differently logic then the one in this package
  (I can't test this, not using it)
- the introduced `unsetEventDispatcher` is also not used anywhere

Can you clarify: if it recommended/required to use _this_ package `RefreshDatabase` trait?

If so, I think the README could be clarified and also if this PR gets accepted, this should be added too (willing to do in this PR once this is cleared up for me).

If not so, then I don't understand why it exists :-)

I certainly needed this modified `DatabaseTransactions` otherwise the actual transactional events where never dispatched in tests.