### PR TITLE
Adapt for Laravel 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "require": {
         "drupol/phptree": "^2.3",
-        "illuminate/database": "~5.8.0",
-        "illuminate/events": "~5.8.0",
-        "illuminate/support": "~5.8.0"
+        "illuminate/database": "~5.8.0|^6.0",
+        "illuminate/events": "~5.8.0|^6.0",
+        "illuminate/support": "~5.8.0|^6.0"
     },
     "authors": [
         {
@@ -33,6 +33,6 @@
         "sort-packages": true
     },
     "require-dev": {
-        "orchestra/testbench": "~3.8.0"
+        "orchestra/testbench": "~3.8.0|~3.9.0"
     }
 }


### PR DESCRIPTION
- add Laravel 6 to version constraint
  - also bumped orchestra, 6 requires 3.9.x
- added PHP 7.4snapshot like the official laravel one