### PR TITLE
[PHPUNIT] Small chore tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 report/
 composer.lock
+.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">


### PR DESCRIPTION
- ignore the result cache file (was introduced more or less recently)
- remove the syntaxCheck attribute, generates a warning (on all versions, see older travis)