### PR TITLE
Remove "final" from TransactionalDispatcher class to allow extending

### DIFF
--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -14,7 +14,7 @@ use loophp\phptree\Node\ValueNodeInterface;
 use Neves\Events\Concerns\DelegatesToDispatcher;
 use Neves\Events\Contracts\TransactionalEvent;
 
-final class TransactionalDispatcher implements DispatcherContract
+class TransactionalDispatcher implements DispatcherContract
 {
     use DelegatesToDispatcher;
 


### PR DESCRIPTION
Hi @fntneves,

This package is great, we've been using it in our app for some time. I'm looking at adding some extra functionality to the dispatcher for our app so want to have an `\App\Events\Dispatcher` class that extends the `\Neves\Events\TransactionalDispatcher`.

This PR removes "final" from the TransactionalDispatcher class to allow extension.