### PR TITLE
[1.8.x] Add namespaced transactional helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
     "autoload": {
         "psr-0": {
             "Neves\\": "src/"
-        }
+        },
+        "files": [
+            "src/Neves/Events/functions.php"
+        ]
     },
     "extra": {
         "laravel": {

--- a/src/Neves/Events/functions.php
+++ b/src/Neves/Events/functions.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Neves\Events;
+
+use Closure;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+
+if (! function_exists('Neves\Events\transactional')) {
+    /**
+     * Build a transactional event for the given closure.
+     *
+     * @param \Closure $callable
+     * @return void
+     */
+    function transactional(Closure $callable)
+    {
+        $dispatcher = app(DispatcherContract::class);
+
+        $dispatcher->dispatch(new TransactionalClosureEvent($callable));
+    }
+}

--- a/tests/TransactionalDispatcherTest.php
+++ b/tests/TransactionalDispatcherTest.php
@@ -2,6 +2,7 @@
 
 use Neves\Events\Contracts\TransactionalEvent;
 use Neves\Events\EventServiceProvider;
+use function Neves\Events\transactional;
 use Neves\Events\TransactionalClosureEvent;
 use Neves\Events\TransactionalDispatcher;
 use Orchestra\Testbench\TestCase;
@@ -276,6 +277,20 @@ class TransactionalDispatcherTest extends TestCase
             $this->dispatcher->dispatch(new TransactionalClosureEvent(function () {
                 $_SERVER['__events'] = 'bar';
             }));
+
+            $this->assertArrayNotHasKey('__events', $_SERVER);
+        });
+
+        $this->assertEquals('bar', $_SERVER['__events']);
+    }
+
+    /** @test */
+    public function it_provides_transactional_behavior_of_custom_closures_using_transactional_helper()
+    {
+        DB::transaction(function () {
+            transactional(function () {
+                $_SERVER['__events'] = 'bar';
+            });
 
             $this->assertArrayNotHasKey('__events', $_SERVER);
         });


### PR DESCRIPTION
This PR recovers the old `transactional` helper.

Similarly to what is happening in Laravel 8, with the introduction of namespaced functions (i.e., `queueable`), this PR aims at easing the usage of this library by introducing a new helper.