### PR TITLE
[1.8] Fix type on constructor

### DIFF
--- a/src/Neves/Events/TransactionalDispatcher.php
+++ b/src/Neves/Events/TransactionalDispatcher.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Database\Events\TransactionBeginning;
 use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Database\Events\TransactionRolledBack;
-use Illuminate\Events\Dispatcher as EventDispatcher;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use loophp\phptree\Node\ValueNode;
@@ -69,7 +68,7 @@ class TransactionalDispatcher implements DispatcherContract
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $eventDispatcher
      */
-    public function __construct(EventDispatcher $eventDispatcher)
+    public function __construct(DispatcherContract $eventDispatcher)
     {
         $this->dispatcher = $eventDispatcher;
         $this->setUpListeners();


### PR DESCRIPTION
Should fix https://github.com/fntneves/laravel-transactional-events/issues/45

Since we "loosen" the constructor args and constructors aren't subject to LSP, I think this should be good for 1.8 and then be merged into master/2.x