### PR TITLE
Add .scrutinizer.yml

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,6 @@
+build:
+  nodes:
+    analysis:
+      dependencies:
+        after:
+          - composer require --dev "squizlabs/php_codesniffer=3.7.2"

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,3 +4,8 @@ build:
       dependencies:
         after:
           - composer require --dev "squizlabs/php_codesniffer=3.7.2"
+
+      tests:
+        override:
+          - command: phpcs-run
+            use_website_config: false

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,5 +7,5 @@ build:
 
       tests:
         override:
-          - command: phpcs-run
+          - command: phpcs-run ./
             use_website_config: false

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,5 +7,5 @@ build:
 
       tests:
         override:
-          - command: phpcs-run ./
+          - command: phpcs-run
             use_website_config: false

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset>
+    <file>./</file>
+    <exclude-pattern>./vendor/*</exclude-pattern>
+    <rule ref="PEAR" />
+</ruleset>


### PR DESCRIPTION
See:
* Config file reference - https://scrutinizer-ci.com/docs/configuration/cascade
* Using a specific phpcs version - https://scrutinizer-ci.com/docs/tools/php/code-sniffer/#using-a-specific-php-code-sniffer-version

Why PEAR? See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-default-coding-standard. Unclear what standard was used on `dev-master`