### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.0, 8.1, 8.2, 8.3]
-        laravel: [10.*, 9.*, 8.*]
+        laravel: [11.*, 10.*, 9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 10.*
             php: 8.0
+          - laravel: 11.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2, 8.3]
         laravel: [10.*, 9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,6 @@ jobs:
         php: [8.0, 8.1, 8.2, 8.3]
         laravel: [10.*, 9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 9.*
-            testbench: ^7.22
-          - laravel: 8.*
-            testbench: ^6.25
         exclude:
           - laravel: 10.*
             php: 8.0
@@ -38,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In the above example the `OrderCreated` event would never be dispatched in the c
  Laravel  | Package  | Notes
 :---------|:----------|:----------
  5.8.x-7.x     | 1.8.x    |
- 8.x-10.x       | 2.x      | >2.1.x requires PHP 8+
+ 8.x-11.x       | 2.x      | >2.1.x requires PHP 8+
 
 ### Laravel
 - Install this package via `composer`:

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
         "illuminate/events": "^8.0|^9.0|^10.0",
         "illuminate/support": "^8.0|^9.0|^10.0"
     },
+    "require-dev": {
+        "orchestra/testbench": "^6.25|^7.22|^8"
+    },
     "authors": [
         {
             "name": "Francisco Neves",

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,9 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "illuminate/database": "^8.0|^9.0|^10.0",
-        "illuminate/events": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0"
-    },
-    "require-dev": {
-        "orchestra/testbench": "^6.25|^7.22|^8"
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/events": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
     },
     "authors": [
         {
@@ -39,6 +36,6 @@
         "sort-packages": true
     },
     "require-dev": {
-        "orchestra/testbench": "^6.25.1|^7.22|^8.0"
+        "orchestra/testbench": "^6.25.1|^7.22|^8.0|^9.0|9.x-dev"
     }
 }


### PR DESCRIPTION
## Summary
On the way I did some smaller improvements:
- test also against PHP 8.3
- bump actions/checkout
- simplify orchestra/testbench version handling